### PR TITLE
修复发送者不保存帖子的问题，重构保存帖子的代码

### DIFF
--- a/Client.java
+++ b/Client.java
@@ -268,7 +268,7 @@ public class Client implements Runnable{
                 try
                 {
                     InetAddress host = InetAddress.getByName(peer.getstrip());
-                    String message = "[2:FF]\r\n"+content+"\r\n";
+                    String message = "[2:FF]\r\n"+content+"\r\n[END]";
                     DatagramPacket datagramPacket = new DatagramPacket(message.getBytes(), message.length(), host, peer.getport());
                     datagramSocket.send(datagramPacket);
                 }

--- a/Client.java
+++ b/Client.java
@@ -2,6 +2,7 @@ import java.io.*;
 import java.net.*;
 import java.sql.*;
 import java.util.logging.*;
+import java.util.LinkedList;
 /**
     处理作为客户端发出请求的种种。包括：请求节点列表，请求帖子列表，泛洪法发送
     帖子。为了使用本类你需要首先用type和dst（可选）构造类的实例：
@@ -191,33 +192,39 @@ public class Client implements Runnable{
                 //把头和尾截掉
                 reply=reply.substring(2,reply.length()-8);
             }
-            //打开数据库
-            Class.forName("org.sqlite.JDBC");
-            Connection conn=DriverManager.getConnection("jdbc:sqlite:Datas.db");
-            String s="INSERT INTO POST(TIME,HASH,PHASH,CONTENT) VALUES(?,?,?,?);";
-            PreparedStatement preStat=conn.prepareStatement(s);
+            
+            LinkedList<Post> postList = new LinkedList<Post>();
             for(String i:reply.split("\\],\\[")){
-                log.info("saving "+i);
                 String[] j=i.split(",");
-                preStat.setLong(1,Long.parseLong(j[0]));
-                preStat.setInt(2,Integer.parseInt(j[1]));
-                preStat.setInt(3,Integer.parseInt(j[2]));
-                preStat.setString(4, Post.reverseEscape(j[3]));
-                try{
-                    preStat.executeUpdate();
-                    preStat.clearParameters();
-                }catch(org.sqlite.SQLiteException e){
-                    preStat=conn.prepareStatement(s);
+                try
+                {
+                    Post post = new Post(Long.parseLong(j[0]), Post.reverseEscape(j[3]), Integer.parseInt(j[2]));
+                    if (Integer.parseInt(j[1]) != post.hashCode())
+                    {
+                        log.warning("post "+i+" hashCode not match");
+                        continue;
+                    }
+                    postList.add(post);
+                }
+                catch (Exception e)
+                {
+                    e.printStackTrace();
                 }
             }
-            preStat.close();conn.close();
+            DataBase.insertPost(postList.toArray(new Post[0]));
         }catch(Exception e){
             e.printStackTrace();
         }
     }
     /**测试sendRPAux功能的函数*/
     public static void testSendRPAux(){
-        String s="[6:RPR]\r\n[[1,2049459487,0,helloworld],[2,2049459488,0,helloworld],]\r\n[END]";
+        //String s="[6:RPR]\r\n[[1,2049459487,0,helloworld],[2,2049459488,0,helloworld],]\r\n[END]";
+        DataBase.delDataBase();
+        DataBase.initTables();
+        Post p1 = new Post(1,"1",0);
+        Post p2 = new Post(2,"2",0);
+        Post p3 = new Post(3,"3",0);
+        String s="[6:RPR]\r\n["+p1.toString()+","+p1.toString()+","+p3.toString()+",]\r\n[END]";
         Client c=new Client((byte)1);
         BufferedReader in=new BufferedReader(new StringReader(s));
         c.sendRPAux(in);

--- a/DataBase.java
+++ b/DataBase.java
@@ -35,6 +35,84 @@ public class DataBase{
             log.warning("del db err");
         }
     }
+    
+    /**将一组帖子插入数据库。如果数据库操作抛出了除了”条目已存在“以外的异常，则返回-1，否则返回成功插入了几条不在数据库中的帖子*/
+    public static int insertPost(Post[] post)
+    {
+        Connection connection = null;
+        PreparedStatement statementInsertPost = null;
+        String statementInsertPost_String = "INSERT INTO POST(TIME,HASH,PHASH,CONTENT) VALUES(?,?,?,?);";
+        boolean unexpectedExceptionOccured = false;
+        int newPostCount = 0;
+        
+        try
+        {
+            Class.forName("org.sqlite.JDBC");
+            connection = DriverManager.getConnection("jdbc:sqlite:Datas.db");
+            statementInsertPost = connection.prepareStatement(statementInsertPost_String);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            return -1;
+        }
+        
+        for (int i=0; i<post.length; ++i)
+        {
+            try
+            {
+                statementInsertPost.clearParameters();
+                statementInsertPost.setLong(1, post[i].getTime());
+                statementInsertPost.setInt(2, post[i].hashCode());
+                statementInsertPost.setInt(3, post[i].getParentHashCode());
+                statementInsertPost.setString(4, post[i].getContent());
+                try
+                {
+                    statementInsertPost.executeUpdate();
+                    newPostCount++;
+                }
+                catch (org.sqlite.SQLiteException e)
+                {
+                    org.sqlite.SQLiteErrorCode errorCode = e.getResultCode();
+                    if (errorCode != org.sqlite.SQLiteErrorCode.SQLITE_CONSTRAINT_PRIMARYKEY)
+                    {
+                        unexpectedExceptionOccured = true;
+                        e.printStackTrace();
+                    }
+                    else
+                    {
+                        log.info("post "+post[i].toString()+" exists");
+                    }
+                    statementInsertPost = connection.prepareStatement(statementInsertPost_String);
+                }
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+        }
+        
+        try
+        {
+            statementInsertPost.close();
+            connection.close();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            log.warning("exception occured while closing");
+            unexpectedExceptionOccured = true;
+        }
+        
+        if (unexpectedExceptionOccured) return -1; else return newPostCount;
+    }
+    
+    /**将一个帖子插入数据库。重载了插入一组帖子的insertPost，返回值与之相同。*/
+    public static int insertPost(Post post)
+    {
+        return insertPost(new Post[]{post});
+    }
+    
     public static void exp1(){
         try{
             Class.forName("org.sqlite.JDBC");

--- a/DesktopGUI.java
+++ b/DesktopGUI.java
@@ -268,7 +268,7 @@ class PostWindow implements MouseListener{
         String label=Btemp.getLabel();
         Post aPost=new Post(Transmission.getNetTime(),JTA.getText());
         Log.info("gen post:"+aPost.toString());
-        Transmission.floodfill(aPost.toString());
+        if (DataBase.insertPost(aPost) == 1) Transmission.floodfill(aPost.toString());
     }
 
     @Override

--- a/Post.java
+++ b/Post.java
@@ -13,7 +13,7 @@ public class Post{
     /**帖子发出的时间，以自纪元以来的秒数表示，为一个long（因为int只能存大约30年）*/
     private long time;
     /**帖子的内容，为一个字符串*/
-    private String  content;
+    private String content;
     /**父帖子的哈希值，为一个int*/
     private int parentHashCode;
     /**以c为内容以t为时间构造Post，parentHashCode默认为THEHASHCODE*/


### PR DESCRIPTION
终于，我写出了保存帖子的（比较）完美的解决办法。
首先，在DataBase里新开了一个函数`insertPost`专门用来保存帖子，因为这样`sendRPAux`和`dealFF`就可以复用保存帖子的代码。建议以后把操作数据库的代码都移到`DataBase`类里去。
其次，从发帖到泛红的逻辑改成：发帖人在点击GUI的post按钮后直接调用`DataBase.insertPost`，然后调用`Transmission.floodfill`泛洪，别的用户用`dealFF`收到帖子后再调用`DataBase.insertPost`。这样设计更符合逻辑。
最后，找到了判断帖子是否存在+插入帖子的最优雅的解决办法。不需要先Select一遍判断存不存在，可以利用插入操作发生的exception的error code来判断这个错误是因为条目重复了还是别的原因，这样只要一次数据库操作就可以解决。然而SQL的error code分粗略code和细分code，而且SQLite原本是C++版的，我读了Java版SQLite的源码才知道怎么获得细分code，天杀的手册根本没说。
另外还做了一些小修改，见代码。

尚不完美的地方：
SQL支持批处理操作，`sendRPAux`需要保存一堆帖子，最好的实现方法就是用批处理，但是万一中途某个帖子出错处理起来很麻烦，据说SQL有的实现会中途停止，有的会忽略错误继续，所以最后还是没这么写。以后可以改成批处理。