### PR TITLE
fix: correct 'occured' to 'occurred' typo in log warning message

### DIFF
--- a/DataBase.java
+++ b/DataBase.java
@@ -132,7 +132,7 @@ public class DataBase{
         catch (Exception e)
         {
             e.printStackTrace();
-            log.warning("exception occured while closing");
+            log.warning("exception occurred while closing");
             unexpectedExceptionOccured = true;
         }
 


### PR DESCRIPTION
## Summary
Fixes typo in user-facing `log.warning()` message in `DataBase.java` line 135:
`exception occured while closing` → `exception occurred while closing`

## Context
This is a user-facing warning message logged when closing a database connection.

---
fix: correct 'occured' to 'occurred' typo in log warning message