### PR TITLE
fix: correct occured to occurred typo in user-facing log warning

### DIFF
--- a/DataBase.java
+++ b/DataBase.java
@@ -132,7 +132,7 @@ public class DataBase{
         catch (Exception e)
         {
             e.printStackTrace();
-            log.warning("exception occured while closing");
+            log.warning("exception occurred while closing");
             unexpectedExceptionOccured = true;
         }
 


### PR DESCRIPTION
Fixes issue #15 - DataBase.java line 135 user-facing log.warning message.

Change: log.warning( exception occured while closing ) -> log.warning( exception occurred while closing )

Submitted via PR攻关 workflow.